### PR TITLE
Status now uses correct Activity

### DIFF
--- a/src/components/Status.vue
+++ b/src/components/Status.vue
@@ -38,7 +38,7 @@ export default {
       if (!lanyard) return {}
 
       const filtered =
-        lanyard.activities?.filter((activity) => activity.type !== 4)?.[0] || {}
+        lanyard.activities?.filter((activity) => activity.type !== 4)?.pop() || {}
 
       // Offline
       if (this.lanyard?.discord_status === "offline") return "Offline"


### PR DESCRIPTION
When playing a game and having a presence at the same time, both have the ID 0, but actual presences are always last, not first. So now the code is looking at the last array item rather than the first...