### PR TITLE
fix: Search duplicates and hidden 404 message

### DIFF
--- a/src/pages/blog/index.vue
+++ b/src/pages/blog/index.vue
@@ -124,7 +124,7 @@
 
     <div
       v-else-if="
-        typeof getFilteredPosts === 'object' && getFilteredPosts.length > 0
+        typeof getFilteredPosts === 'object' && getFilteredPosts.length >= 0
       "
     >
       <div v-if="getFilteredPosts.length === 0" class="space-y-4">
@@ -287,7 +287,7 @@ export default Vue.extend({
               ?.includes(q || search || query || ara || sorgu || "")
         )
 
-        console.log([...new Map(filteredPosts.map(item => [item.title, item])).values()])
+        console.log(typeof [...new Map(filteredPosts.map(item => [item.title, item])).values()])
         return [...new Map(filteredPosts.map(item => [item.title, item])).values()]
       }
     },

--- a/src/pages/blog/index.vue
+++ b/src/pages/blog/index.vue
@@ -22,7 +22,9 @@
       </div>
 
       <div class="mt-14 grid gap-14 md:(gap-4 grid-cols-2)">
-        <div class="flex flex-col space-y-2 overflow-x-hidden md:overflow-visible">
+        <div
+          class="flex flex-col space-y-2 overflow-x-hidden md:overflow-visible"
+        >
           <SmartLink
             :href="{
               name: 'blog',
@@ -51,7 +53,9 @@
           </template>
         </div>
 
-        <div class="flex flex-col space-y-2 overflow-x-hidden md:overflow-visible">
+        <div
+          class="flex flex-col space-y-2 overflow-x-hidden md:overflow-visible"
+        >
           <SmartLink
             :href="{
               name: 'blog',
@@ -83,7 +87,12 @@
 
       <div class="mt-16">
         <h3
-          class="font-semibold space-x-2 text-lg text-gray-900 dark:text-gray-100"
+          class="
+            font-semibold
+            space-x-2
+            text-lg text-gray-900
+            dark:text-gray-100
+          "
         >
           Diğer gönderiler
         </h3>
@@ -107,10 +116,24 @@
           <div
             v-for="page in getTotalPages"
             :key="`pagination-${page}`"
-            class="rounded-full cursor-pointer flex font-medium bg-gray-200 h-10 ring-1 ring-gray-300 text-gray-900 w-10 items-center justify-center select-none dark:(bg-gray-800
+            class="
+              rounded-full
+              cursor-pointer
+              flex
+              font-medium
+              bg-gray-200
+              h-10
+              ring-1 ring-gray-300
+              text-gray-900
+              w-10
+              items-center
+              justify-center
+              select-none
+              dark:(bg-gray-800
               ring-gray-800
               text-gray-100
-              hover:bg-gray-700) hover:bg-gray-300"
+              hover:bg-gray-700) hover:bg-gray-300
+            "
             :class="{
               'bg-gray-300 dark:bg-gray-700': pagination + 1 === page,
             }"
@@ -122,17 +145,19 @@
       </div>
     </div>
 
-    <div
-      v-else-if="
-        typeof getFilteredPosts === 'object'
-      "
-    >
-      <div v-if="getFilteredPosts.length === 0"
-      class="space-y-4"
-      :class="{'hidden': isFetchPending}"
+    <div v-else-if="typeof getFilteredPosts === 'object'">
+      <div
+        v-if="getFilteredPosts.length === 0"
+        class="space-y-4"
+        :class="{ hidden: isFetchPending }"
       >
         <h2
-          class="font-semibold text-2xl text-gray-900 md:text-4xl dark:text-gray-100"
+          class="
+            font-semibold
+            text-2xl text-gray-900
+            md:text-4xl
+            dark:text-gray-100
+          "
         >
           Aramanıza uygun herhangi bir gönderi bulunamadı.
         </h2>
@@ -154,10 +179,23 @@
 
         <SmartLink
           :href="{ name: 'blog' }"
-          class="rounded flex space-x-2 bg-gray-100 py-2 px-4 ring-1 ring-gray-200 text-gray-900 items-center justify-center md:w-max dark:(bg-gray-800
+          class="
+            rounded
+            flex
+            space-x-2
+            bg-gray-100
+            py-2
+            px-4
+            ring-1 ring-gray-200
+            text-gray-900
+            items-center
+            justify-center
+            md:w-max
+            dark:(bg-gray-800
             ring-gray-700
             text-gray-100
-            hover:bg-gray-700) hover:bg-gray-200"
+            hover:bg-gray-700) hover:bg-gray-200
+          "
         >
           <IconHome class="h-6 w-6" />
           <span>Bloga Dön</span>
@@ -290,7 +328,9 @@ export default Vue.extend({
               ?.includes(q || search || query || ara || sorgu || "")
         )
 
-        return [...new Map(filteredPosts.map(item => [item.title, item])).values()]
+        return [
+          ...new Map(filteredPosts.map((item) => [item.title, item])).values(),
+        ]
       }
     },
     /**

--- a/src/pages/blog/index.vue
+++ b/src/pages/blog/index.vue
@@ -287,7 +287,6 @@ export default Vue.extend({
               ?.includes(q || search || query || ara || sorgu || "")
         )
 
-        console.log(typeof [...new Map(filteredPosts.map(item => [item.title, item])).values()])
         return [...new Map(filteredPosts.map(item => [item.title, item])).values()]
       }
     },

--- a/src/pages/blog/index.vue
+++ b/src/pages/blog/index.vue
@@ -124,10 +124,13 @@
 
     <div
       v-else-if="
-        typeof getFilteredPosts === 'object' && getFilteredPosts.length >= 0
+        typeof getFilteredPosts === 'object'
       "
     >
-      <div v-if="getFilteredPosts.length === 0" class="space-y-4">
+      <div v-if="getFilteredPosts.length === 0"
+      class="space-y-4"
+      :class="{'hidden': isFetchPending}"
+      >
         <h2
           class="font-semibold text-2xl text-gray-900 md:text-4xl dark:text-gray-100"
         >

--- a/src/pages/blog/index.vue
+++ b/src/pages/blog/index.vue
@@ -287,7 +287,8 @@ export default Vue.extend({
               ?.includes(q || search || query || ara || sorgu || "")
         )
 
-        return filteredPosts
+        console.log([...new Map(filteredPosts.map(item => [item.title, item])).values()])
+        return [...new Map(filteredPosts.map(item => [item.title, item])).values()]
       }
     },
     /**


### PR DESCRIPTION
Hey there,

I've noticed that your search feature returns duplicate results. I've forked your repo and run it locally to do a few tests. I have fixed this issue by returning posts inside a set.

In addition to that, the 404 message wasn't displayed when no results were found. I've managed it to make it appear but also avoid flashing (the message was appearing and disappearing on page loads) with a dynamic class.

I hope you'll like the way I've fixed these issues.

![search-message](https://i.imgur.com/pM6Xno0.png)
![duplicate-posts](https://i.imgur.com/lssPcSN.png)