### PR TITLE
Visual Fixes

### DIFF
--- a/src/components/CommandPalette/Index.vue
+++ b/src/components/CommandPalette/Index.vue
@@ -186,7 +186,7 @@ export default Vue.extend({
       @click="() => toggleVisibility(false)"
     >
       <div
-        class="lg:h-1/2 lg:w-1/2 w-full h-full overflow-hidden scrollbar relative lg:rounded-lg lg:mt-24 ring-1 ring-white/10 dark:bg-neutral-900 bg-gray-200 text-neutral-900 dark:text-white"
+        class="lg:h-1/2 lg:w-1/2 w-full h-full overflow-hidden relative lg:rounded-lg lg:mt-24 ring-1 ring-white/10 dark:bg-neutral-900 bg-gray-200 text-neutral-900 dark:text-white"
         @click="(e) => e.stopPropagation()"
       >
         <!-- Search bar -->
@@ -207,7 +207,7 @@ export default Vue.extend({
 
         <!-- Content -->
         <div
-          class="pt-13 space-y-4 pb-3.5 px-1.5 overflow-y-auto h-full text-neutral-600 space-y-1"
+          class="pt-13 space-y-4 pb-3.5 px-1.5 overflow-y-auto scrollbar h-full text-neutral-600 space-y-1"
         >
           <div
             v-for="(item, index) in getCategoriesFiltered"

--- a/src/pages/donate.vue
+++ b/src/pages/donate.vue
@@ -194,13 +194,14 @@ export default Vue.extend({
               class="w-full py-4"
             />
 
-            <p v-else-if="$fetchState.error !== null">An error occured.</p>
+            <p v-else-if="$fetchState.error" class="mx-4">An error occured.</p>
             <p
               v-else-if="
                 !$fetchState.pending &&
                 !$fetchState.error &&
                 sponsors.length === 0
               "
+              class="mx-4"
             >
               No sponsors yet :(
             </p>


### PR DESCRIPTION
There's also a bug in Firefox on donate page. GitHub Sponsors are not loading because of CORS Preflight. The solution is adding the `Access-Control-Request-Headers` header to the request, but Axios header options are _still_ broken and don't add the header properly to the request. I fixed it locally by using `fetch` API, but I'm in doubt if I should push it since the project's target Node version is 16, and `fetch` is experimental on that version and it will be different from all other request code blocks.

I am attaching the patch below. If you accept, I will add the change to the PR.
```diff
diff --git a/src/pages/donate.vue b/src/pages/donate.vue
index c22d659..05663af 100644
--- a/src/pages/donate.vue
+++ b/src/pages/donate.vue
@@ -57,9 +57,15 @@ export default Vue.extend({
   },
   fetchOnServer: false,
   async fetch() {
-    const { data } = await this.$axios.get(
-      "https://raw.githubusercontent.com/eggsy/.github/main/sponsors.json"
-    )
+    const response = await fetch(
+        "https://raw.githubusercontent.com/eggsy/.github/main/sponsors.json",
+        {
+          headers: {
+            "Access-Control-Request-Headers": "allow, content-type",
+          },
+        }
+      ),
+      data = await response.json()
 
     this.sponsors = data
   },
```

## Changes

### `fix(CommandPalette.vue): scrollbar attributes not working on firefox`
Before:
![image](https://user-images.githubusercontent.com/108196023/192756982-47230338-0cad-4b88-b69d-a692860de324.png)
After:
![image](https://user-images.githubusercontent.com/108196023/192757012-23934131-bd7c-4818-a57d-99cc9e6b6d09.png)

### `fix(donate.vue): align error and no sponsor texts`
Before:
![image](https://user-images.githubusercontent.com/108196023/192756534-01dce0a0-56b4-4a85-8d2b-1c010f1463b6.png)
After: 
![image](https://user-images.githubusercontent.com/108196023/192756872-ae23cd6e-44f8-4ef9-a1d1-a8b71f2d9c19.png)