### PR TITLE
fix: Spelling error in the square background and failed to load

### DIFF
--- a/components/SquaresBackground.vue
+++ b/components/SquaresBackground.vue
@@ -16,7 +16,7 @@ const props = withDefaults(
 )
 
 const gridOffset = ref({ x: 0, y: 0 })
-const requestRef = ref<number | null>(0)
+const requestRef = ref<number | null>(null)
 const numSquaresX = ref(0)
 const numSquaresY = ref(0)
 const canvas = ref<HTMLCanvasElement>()
@@ -84,7 +84,7 @@ const drawGrid = () => {
     0,
     canvas.value.width / 2,
     canvas.value.height / 2,
-    Math.sqrt(canvas.value.width ** 2 + canvas.value.height ** 2) / 2,
+    Math.hypot(canvas.value.width / 2, canvas.value.height / 2),
   )
 
   gradient.addColorStop(0, "rgba(0, 0, 0, 0)")

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -43,11 +43,11 @@ useHead({
   >
     <div class="flex items-center gap-8">
       <div
-        class="hidden dark:block absolute inset-0 pointer-events-none overflow-hidden z-0 opacity-5"
+        class="absolute inset-0 pointer-events-none overflow-hidden z-50 opacity-5"
       >
         <SquaresBackground
           :speed="0.3"
-          :sqaure-size="5"
+          :squareSize="40"
           class="w-full h-full"
         />
       </div>


### PR DESCRIPTION
1. Changed `Math.sqrt` to `Math.hypot`
2. Fixed the spelling error `sqaure-size` to `squareSize`
3. Set the default value of `requestRef` to `null`